### PR TITLE
use closest() instead of parents() (fixes #1)

### DIFF
--- a/jquery.edittable.js
+++ b/jquery.edittable.js
@@ -144,7 +144,7 @@
         // Add column
         $table.on('click', '.addcol', function () {
 
-            var colid = parseInt($(this).parents('tr').children().index($(this).parent('th')), 10);
+            var colid = parseInt($(this).closest('tr').children().index($(this).parent('th')), 10);
 
             colnumber += 1;
 
@@ -166,7 +166,7 @@
                 return false;
             }
 
-            var colid = parseInt($(this).parents('tr').children().index($(this).parent('th')), 10);
+            var colid = parseInt($(this).closest('tr').children().index($(this).parent('th')), 10);
 
             colnumber -= 1;
 
@@ -190,7 +190,7 @@
 
             rownumber += 1;
 
-            $(this).parents('tr').after(buildRow(0, colnumber));
+            $(this).closest('tr').after(buildRow(0, colnumber));
 
             $table.find('.delrow').removeClass('disabled');
 
@@ -210,7 +210,7 @@
 
             checkButtons();
 
-            $(this).parents('tr').remove();
+            $(this).closest('tr').remove();
 
             $table.find('.addrow').removeClass('disabled');
 


### PR DESCRIPTION
The parents() function traverses the entire DOM, so if the textarea is inside a table, too many elements are added or deleted. The closest() function works almost identically, except it stops after finding the first occurrence of the passed element (in this case, the nearest <tr>).
